### PR TITLE
[HOTFIX] Muda formato de receitas em progresso no localStorage

### DIFF
--- a/cypress/integration/recipe_detail_spec.js
+++ b/cypress/integration/recipe_detail_spec.js
@@ -291,9 +291,9 @@ describe('Caso a receita tenha sido iniciada mas não finalizada, o texto do bot
   it('Verifica botão de "Continuar Receita" na tela de detalhes de uma comida', () => {
     cy.visit('http://localhost:3000/comidas/52771', {
       onBeforeLoad(win) {
-        const inProgressRecipes = [{
+        const inProgressRecipes = {
           52771: []
-        }];
+        };
         localStorage.setItem('inProgressRecipes', JSON.stringify(inProgressRecipes));
         win.fetch = fetchMock;
       },
@@ -305,9 +305,9 @@ describe('Caso a receita tenha sido iniciada mas não finalizada, o texto do bot
   it('Verifica botão de "Continuar Receita" na tela de detalhes de uma bebida', () => {
     cy.visit('http://localhost:3000/bebidas/178319', {
       onBeforeLoad(win) {
-        const inProgressRecipes = [{
+        const inProgressRecipes = {
           178319: []
-        }];
+        };
         localStorage.setItem('inProgressRecipes', JSON.stringify(inProgressRecipes));
         win.fetch = fetchMock;
       },

--- a/cypress/integration/recipe_detail_spec.js
+++ b/cypress/integration/recipe_detail_spec.js
@@ -292,7 +292,9 @@ describe('Caso a receita tenha sido iniciada mas não finalizada, o texto do bot
     cy.visit('http://localhost:3000/comidas/52771', {
       onBeforeLoad(win) {
         const inProgressRecipes = {
-          52771: []
+          meals: {
+            52771: [],
+          },
         };
         localStorage.setItem('inProgressRecipes', JSON.stringify(inProgressRecipes));
         win.fetch = fetchMock;
@@ -306,7 +308,9 @@ describe('Caso a receita tenha sido iniciada mas não finalizada, o texto do bot
     cy.visit('http://localhost:3000/bebidas/178319', {
       onBeforeLoad(win) {
         const inProgressRecipes = {
-          178319: []
+          cocktails: {
+            178319: [],
+          },
         };
         localStorage.setItem('inProgressRecipes', JSON.stringify(inProgressRecipes));
         win.fetch = fetchMock;


### PR DESCRIPTION
- [Espera-se](https://github.com/betrybe/sd-0x-recipes-app-n#localstorage) que as receitas em progresso sejam salvas no localStorage dentro de um objeto.
- Teve 2 testes que consideraram que tais receitas sejam salvas em um array. Este PR corrige o formato em tais testes.
- Já tem um [PR](https://github.com/betrybe/sd-0x-recipes-app-N/pull/20) criado no repositório template a ser disponibilizado por estudantes para atualizar o README de forma que converse com o que foi alterado de testes aqui.