### PR TITLE
Enhancements/tests

### DIFF
--- a/cypress/integration/explore_by_ingredient_spec.js
+++ b/cypress/integration/explore_by_ingredient_spec.js
@@ -78,7 +78,7 @@ describe('A tela deve ter cards para os 12 primeiros ingredientes, de forma que 
   });
 });
 
-describe(' Ao clicar no card do ingrediente a rota deve mudar para tela principal de receitas, mas mostrando apenas as receitas que contém o ingrediente escolhido', () => {
+describe('Ao clicar no card do ingrediente a rota deve mudar para tela principal de receitas, mas mostrando apenas as receitas que contém o ingrediente escolhido', () => {
   it('Ao clicar no card do ingrediente da tela de explorar comidas por ingrediente a rota muda para a tela principal de receitas filtrada pelo ingrediente', () => {
     cy.visit('http://localhost:3000/explorar/comidas/ingredientes', {
       onBeforeLoad(win) {

--- a/cypress/integration/recipe_in_progress_spec.js
+++ b/cypress/integration/recipe_in_progress_spec.js
@@ -69,6 +69,11 @@ describe('A lista de ingredientes deve conter um checkbox para cada um dos items
 });
 
 describe('Ao clicar no checkbox de um ingrediente, o nome dele deve ser "riscado" da lista', () => {
+  const getIngredients = () => (
+    cy.get('[data-testid*="ingredient-step"]')
+      .find('input[type="checkbox"]')
+  );
+
   it('verifica se é possível marcar todos os passos da receita de comida', () => {
     cy.visit('http://localhost:3000/comidas/52771/in-progress', {
       onBeforeLoad(win) {
@@ -76,9 +81,10 @@ describe('Ao clicar no checkbox de um ingrediente, o nome dele deve ser "riscado
       },
     });
 
-    cy.get('[data-testid*="ingredient-step"]')
-      .find('input[type="checkbox"]')
-      .check()
+    getIngredients()
+      .check();
+
+    getIngredients()
       .should('have.css', 'text-decoration', 'none solid rgb(0, 0, 0)');
   });
 
@@ -89,9 +95,10 @@ describe('Ao clicar no checkbox de um ingrediente, o nome dele deve ser "riscado
       },
     });
 
-    cy.get('[data-testid*="ingredient-step"]')
-      .find('input[type="checkbox"]')
-      .check()
+    getIngredients()
+      .check();
+
+    getIngredients()
       .should('have.css', 'text-decoration', 'none solid rgb(0, 0, 0)');
   });
 });
@@ -455,7 +462,6 @@ describe('O botão de finalizar receita só pode estar habilitado quando todos o
     cy.get('[data-testid="finish-recipe-btn"]').should('be.enabled');
   });
 });
-
 
 describe('Após clicar no botão "Finalizar receita", a rota deve mudar para a página de receitas feitas, cuja rota deve ser `/receitas-feitas`', () => {
   it('redireciona após concluir uma receita de comida', () => {


### PR DESCRIPTION
1. Ajusta os testes referentes ao requisito **Ao clicar no checkbox de um ingrediente, o nome dele deve ser "riscado" da lista**, de modo que resolva problemas de asincronicidade por conta de atualização de estado em React, que é assíncrono. A forma feita para resolver tal problema é feita busca pelos inputs do tipo `checkbox` para os ingredientes 2 vezes: uma para poder fazer o check, outra para poder verificar se os inputs estão devidamente checkados.
2. Remove um espaço extra na mensagem do describe para o [requisito 50](https://github.com/betrybe/sd-0x-recipes-app-n#50---ao-clicar-no-checkbox-de-um-ingrediente-o-nome-dele-deve-ser-riscado-da-lista). 

OBS: no que diz respeito segundo ponto anterior, o arquivo de requisitos presente no template `sd-0x-recipes-app-n` [já está formatado adequadamente](https://github.com/betrybe/sd-0x-recipes-app-N/blob/master/.trybe/requirements.json#L231). O arquivo `cypress/integration/explore_by_ingredient_spec.js` neste PR agora é o mesmo [presente no template](https://github.com/betrybe/sd-0x-recipes-app-N/blob/master/cypress/integration/explore_by_ingredient_spec.js)