### PR TITLE
[HOTFIX] Ajusta mensagens dos testes

### DIFF
--- a/cypress/integration/explore_spec.js
+++ b/cypress/integration/explore_spec.js
@@ -19,7 +19,7 @@ describe('A tela deve ter dois botões: um para explorar comidas e o outro para 
 });
 
 
-describe('A tela deve ter dois botões: um para explorar comidas e o outro para explorar bebidas', () => {
+describe('Ao clicar em um dos botões, a rota deve mudar para a página de explorar comidas ou de explorar bebidas', () => {
   it('O nomes dos botões devem ser "Explorar Comidas" e "Explorar Bebidas"', () => {
     cy.visit('http://localhost:3000/explorar');
 

--- a/cypress/integration/favorite_recipes_spec.js
+++ b/cypress/integration/favorite_recipes_spec.js
@@ -104,7 +104,7 @@ describe('Favorite recipes screen', () => {
     });
   });
 
-  describe('O botão de "desfavoritar" deve remover a receita da lista de receitas favoritas do localStorage e da tela.', () => {
+  describe('O botão de "desfavoritar" deve remover a receita da lista de receitas favoritas do localStorage e da tela', () => {
     it('Ao clicar no botão de "desfavoritar" a respectiva receita é removida da tela', () => {
       cy.get('[data-testid="0-horizontal-name"]').contains(favoriteRecipes[0].name);
       cy.get('[data-testid="1-horizontal-name"]').contains(favoriteRecipes[1].name);


### PR DESCRIPTION
Este PR ajusta as mensagens de 2 testes, de modo que correspondem com o que está presente no arquivo de [requisitos](https://github.com/betrybe/sd-0x-recipes-app-N/blob/master/.trybe/requirements.json) 

OBS: 
1. o arquivo de requisitos presente no template `sd-0x-recipes-app-n` [já está formatado adequadamente](https://github.com/betrybe/sd-0x-recipes-app-N/blob/master/.trybe/requirements.json#L231).
2. Os arquivos `cypress/integration/explore_spec.js` e `cypress/integration/favorite_recipes_spec.js` neste PR agora correspondem aos arquivos [explore_spec](https://github.com/betrybe/sd-0x-recipes-app-N/blob/master/cypress/integration/explore_spec.js) e [favorite_recipes_spec](https://github.com/betrybe/sd-0x-recipes-app-N/blob/master/cypress/integration/favorite_recipes_spec.js) presentes no template, respectivamente.